### PR TITLE
Flush out and add to VPN and networking sections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Contributions *very welcome* but first see [Contributing](#contributing).
   - [VM-Hardening](#vm-hardening)
   - [Desktop Customization](#desktop-customization)
   - [GPU](#gpu)
-  - [Clear Net \& Darknet Networking](#clear-net--darknet-networking)
+  - [Clearnet \& Anonymous Networking](#clearnet--anonymous-networking)
     - [VPN](#vpn)
-    - [Darknet](#darknet)
+    - [Anonymity](#anonymity)
     - [Crypto](#crypto)
   - [Kernels](#kernels)
     - [Microkernels](#microkernels)
@@ -202,16 +202,20 @@ Contributions *very welcome* but first see [Contributing](#contributing).
 - [Nvidia-troubleshooting](https://github.com/Qubes-Community/Contents/blob/master/docs/troubleshooting/nvidia-troubleshooting.md) - 
 - [Gaming-HVM](https://github.com/Qubes-Community/Contents/blob/master/docs/customization/gaming-hvm.md) - 
 
-## Clear Net & Darknet Networking
+## Clearnet & Anonymous Networking
 
 ### VPN
 
-- [How To make a VPN Gateway in Qubes](https://github.com/Qubes-Community/Contents/blob/master/docs/configuration/vpn.md) - Qubes includes a number of tools that can make the client-side setup of your VPN more versatile and secure.
-- [Qubes-Tunnel](https://github.com/QubesOS-contrib/qubes-tunnel) - Manage, run, protect VPN connections in Proxy VMs.
-- [Mullvad VPN](https://mullvad.net/en/help/qubes-os-4-and-mullvad-vpn/) - Privacy first VPN provider in Qubes OS.
+#### Wireguard
+- [Mullvad VPN (FE36 + WG)](https://mullvad.net/en/help/wireguard-on-qubes-os/) - Privacy-first VPN provider's guide for Qubes OS. This guide bears an optimal method for setting up a WG ProxyVM (i.e `sys-vpn`); you may substitute out Mullvad's WG configuration files in place of your own. 
 - [WireGuard](https://github.com/Qubes-Community/Contents/tree/master/docs/wireguard) - WireGuard: fast, modern, secure VPN tunnel.
 
-### Darknet
+#### OpenVPN
+- [How To make a VPN Gateway in Qubes](https://github.com/Qubes-Community/Contents/blob/master/docs/configuration/vpn.md) - Qubes includes a number of tools that can make the client-side setup of your VPN more versatile and secure.
+- [Qubes-Tunnel](https://github.com/QubesOS-contrib/qubes-tunnel) - Manage, run, protect VPN connections in Proxy VMs.
+- [Mullvad VPN (DEB10 + OVPN)](https://mullvad.net/en/help/qubes-os-4-and-mullvad-vpn/) - Privacy-first VPN provider's guide for Qubes OS.
+
+### Anonymity
 
 - [i2p-Whonix](https://forum.qubes-os.org/t/temporary-way-to-run-i2p-on-qubes-whonix/15861) - Temporary way to run i2p on Qubes-Whonix.
 - [ipfs](https://github.com/ipfs/ipfs) - A peer-to-peer hypermedia protocol to make the web faster, safer, and more open.


### PR DESCRIPTION
Proposed changes:

- Split the VPN section into Wireguard and OVPN.
- Differentiated between the existing Mullvad OVPN guide link and their (more current) guide for Wireguard on Qubes.
- Added description to Mullvad WG guide, as it can be used as a quick way to deploy a VPN ProxyVM with any WG config files and peers.
- Renamed the "Darknet" header to "Anonymity" and the overall section header to "Clearnet & Anonymous Networking" - Darknet adds a certain connotation to what these projects do, what they're used for, and what they're used for by Qubes users. This isn't right; and we in the privacy world especially know well enough the arguments and the user metrics for Whonix, Tor, and i2p as being a means for good.
  - These projects are also billed as, and exist for the primary purposes of anonymity, I assume the "darknet" term usage here was simply informal shorthand.
  - Speaking of shorthand, "Clear Net" has been changed to the correct "Clearnet".

Signed-off-by: mehrexe [49566023+mehrexe@users.noreply.github.com](mailto:49566023+mehrexe@users.noreply.github.com)